### PR TITLE
Correct wifi auth types for esp32

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -394,7 +394,7 @@ function can be used.
 - `cfg` table to hold configuration:
     - `ssid` SSID chars 1-32
     - `pwd` password chars 8-64
-    - `auth` authentication method, one of `wifi.OPEN`, `wifi.WPA_PSK`, `wifi.WPA2_PSK` (default), `wifi.WPA_WPA2_PSK`
+    - `auth` authentication method, one of `wifi.AUTH_OPEN`, `wifi.AUTH_WPA_PSK`, `wifi.AUTH_WPA2_PSK` (default), `wifi.AUTH_WPA_WPA2_PSK`
     - `channel` channel number 1-14 default = 11
     - `hidden` false = not hidden, true = hidden, default = false
     - `max` maximum number of connections 1-4 default=4


### PR DESCRIPTION
Correcting the AP config auth types. 

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

The AP config auth types defined in the current documentation don't seem to exist.  These are updated based on the implementation.
